### PR TITLE
Performing a transaction

### DIFF
--- a/test/tests/session.ts
+++ b/test/tests/session.ts
@@ -1,0 +1,47 @@
+import {makeClient, mockSession} from '@wharfkit/mock-data'
+
+import ContractKit, {Contract} from '$lib'
+import {Action} from '@greymass/eosio'
+import {TransactABIDef} from '@wharfkit/session'
+
+const mockClient = makeClient('https://jungle4.greymass.com')
+
+suite('Session', () => {
+    let mockKit: ContractKit
+    let tokenContract: Contract
+
+    setup(async function () {
+        mockKit = new ContractKit({
+            client: mockClient,
+        })
+        tokenContract = await mockKit.load('eosio.token')
+    })
+
+    suite('transact', function () {
+        test('passes abi data', async function () {
+            // Action to perform
+            const action: Action = tokenContract.action('transfer', {
+                from: 'foo',
+                to: 'bar',
+                quantity: '10.0000 EOS',
+                memo: '',
+            })
+            // ABIs to perform the transaction
+            const abis: TransactABIDef[] = [
+                {
+                    account: tokenContract.account,
+                    abi: tokenContract.abi,
+                },
+            ]
+            // Passing data to transact
+            await mockSession.transact(
+                {
+                    action,
+                },
+                {
+                    abis,
+                }
+            )
+        })
+    })
+})


### PR DESCRIPTION
This PR includes a test showing how we'd pass the data to a `session.transact` call.

Now that the contract no longer has a `contract.call` method, we lost the one place where we could pass in the ABI automatically for the developer trying to perform a transaction. 

I'm trying to figure out the best way to add this functionality back in. 

One idea I had: Could we have a `ContractAction` which extends `Action`, that is the same thing as an `Action` except with a `Contract` saved to it? If the `contract.action('transfer')` call returned one of these ContractAction instances and that's what was passed to the session kit, the session kit could just extract the ABI from the Contract automatically during `transact`.