### PR TITLE
Removing generics to serve as a reset to re-add

### DIFF
--- a/src/contract/table-cursor.ts
+++ b/src/contract/table-cursor.ts
@@ -1,4 +1,13 @@
-import {API, Serializer} from '@greymass/eosio'
+import {
+    API,
+    Checksum160,
+    Checksum256,
+    Float64,
+    Name,
+    Serializer,
+    UInt128,
+    UInt64,
+} from '@greymass/eosio'
 import {wrapIndexValue} from '../utils'
 import {Query, Table} from './table'
 
@@ -6,19 +15,17 @@ interface TableCursorParams {
     table: Table
     tableParams: API.v1.GetTableRowsParams
     maxRows?: number
-    next_key?: API.v1.TableIndexType | string
+    next_key?: Name | UInt64 | UInt128 | Float64 | Checksum256 | Checksum160 | undefined
     indexPositionField?: string
 }
 
 /**
  * Represents a cursor for a table in the blockchain. Provides methods for
  * iterating over the rows of the table.
- *
- * @typeparam TableRow The type of rows in the table.
  */
-export class TableCursor<TableRow> {
+export class TableCursor {
     private table: Table
-    private next_key: API.v1.TableIndexType | string | undefined
+    private next_key: Name | UInt64 | UInt128 | Float64 | Checksum256 | Checksum160 | undefined
     private tableParams: API.v1.GetTableRowsParams
     private endReached = false
     private indexPositionField?: string
@@ -27,9 +34,6 @@ export class TableCursor<TableRow> {
 
     /**
      * @param {TableCursorParams} params - Parameters for creating a new table cursor.
-     *
-     * @param {TableRow[]} params.rows - An array of rows that the cursor will iterate over.
-     * Each row represents an entry in the table.
      *
      * @param {Table} params.table - The table that the rows belong to.
      *
@@ -75,7 +79,7 @@ export class TableCursor<TableRow> {
      *
      * @returns The new rows.
      */
-    async next(rowsPerAPIRequest?: number): Promise<TableRow[]> {
+    async next(rowsPerAPIRequest?: number): Promise<any[]> {
         if (this.endReached) {
             return []
         }
@@ -150,7 +154,7 @@ export class TableCursor<TableRow> {
      * @returns All rows in the cursor query.
      */
     async all() {
-        const rows: TableRow[] = []
+        const rows: any[] = []
         for await (const row of this) {
             rows.push(row)
         }

--- a/src/contract/table.ts
+++ b/src/contract/table.ts
@@ -1,4 +1,4 @@
-import {ABI, ABISerializableConstructor, API, Name, NameType, Serializer} from '@greymass/eosio'
+import {ABI, API, Name, NameType, Serializer} from '@greymass/eosio'
 import type {Contract} from '../contract'
 import {indexPositionInWords, wrapIndexValue} from '../utils'
 import {TableCursor} from './table-cursor'
@@ -40,11 +40,11 @@ export interface GetTableRowsOptions {
  *
  * @typeparam TableRow The type of rows in the table.
  */
-export class Table<TableRow extends ABISerializableConstructor = ABISerializableConstructor> {
+export class Table {
     readonly abi: ABI.Table
     readonly name: Name
     readonly contract: Contract
-    readonly rowType?: TableRow
+    readonly rowType?
 
     private fieldToIndex?: any
 
@@ -53,7 +53,7 @@ export class Table<TableRow extends ABISerializableConstructor = ABISerializable
     /**
      * Constructs a new `Table` instance.
      *
-     * @param {TableParams<TableRow>} tableParams - Parameters for the table.
+     * @param {TableParams} tableParams - Parameters for the table.
      * The parameters should include:
      *  - `contract`: Name of the contract that this table is associated with.
      *  - `name`: Name of the table.
@@ -61,7 +61,7 @@ export class Table<TableRow extends ABISerializableConstructor = ABISerializable
      *  - `rowType`: (optional) Custom row type.
      *  - `fieldToIndex`: (optional) Mapping of fields to their indices.
      */
-    constructor({contract, name, rowType, fieldToIndex}: TableParams<TableRow>) {
+    constructor({contract, name, rowType, fieldToIndex}: TableParams) {
         this.name = Name.from(name)
 
         const abi = contract.abi.tables.find((table) => this.name.equals(table.name))
@@ -101,7 +101,7 @@ export class Table<TableRow extends ABISerializableConstructor = ABISerializable
      *  - `limit`: Maximum number of rows to return.
      * @returns {TableCursor<TableRow>} Promise resolving to a `TableCursor` of the filtered table rows.
      */
-    query(query: Query): TableCursor<TableRow> {
+    query(query: Query): TableCursor {
         const {from, to, rowsPerAPIRequest} = query
 
         const tableRowsParams = {
@@ -132,7 +132,7 @@ export class Table<TableRow extends ABISerializableConstructor = ABISerializable
     async get(
         queryValue: API.v1.TableIndexType | string,
         {scope = this.contract.account, index, key_type}: QueryOptions = {}
-    ): Promise<TableRow> {
+    ) {
         const fieldToIndexMapping = this.getFieldToIndex()
 
         const tableRowsParams = {
@@ -171,7 +171,7 @@ export class Table<TableRow extends ABISerializableConstructor = ABISerializable
      *  - `limit`: Maximum number of rows to return.
      * @returns {TableCursor<TableRow>} Promise resolving to a `TableCursor` of the table rows.
      */
-    first(maxRows: number, options: QueryOptions = {}): TableCursor<TableRow> {
+    first(maxRows: number, options: QueryOptions = {}): TableCursor {
         const tableRowsParams = {
             table: this.name,
             limit: maxRows,
@@ -189,9 +189,9 @@ export class Table<TableRow extends ABISerializableConstructor = ABISerializable
 
     /**
      * Returns a cursor to get every single rows on the table.
-     * @returns {TableCursor<TableRow>}
+     * @returns {TableCursor}
      */
-    cursor(): TableCursor<TableRow> {
+    cursor(): TableCursor {
         const tableRowsParams = {
             table: this.name,
             code: this.contract.account,
@@ -209,7 +209,7 @@ export class Table<TableRow extends ABISerializableConstructor = ABISerializable
      * Returns all the rows from the table.
      * @returns {Promise<TableRow[]>} Promise resolving to an array of table rows.
      */
-    async all(): Promise<TableRow[]> {
+    async all(): Promise<any[]> {
         return this.cursor().all()
     }
 

--- a/test/tests/table.ts
+++ b/test/tests/table.ts
@@ -89,8 +89,8 @@ suite('Table', () => {
             assert.instanceOf(table, Table)
             const rows = await table.first(1).next()
             assert.instanceOf(rows[0], NameBid)
-            // assert.instanceOf(rows[0].newname, Name)
-            console.log(JSON.stringify(rows[0].newname))
+            assert.instanceOf(rows[0].newname, Name)
+            assert.instanceOf(rows[0].high_bid, Int64)
         })
         suite('all', () => {
             test('should return every single row in a table', async () => {


### PR DESCRIPTION
This PR removes all of the generics that were implemented to start as a clean slate, in order to re-implement them. 

The tests are all passing here. 