### PR TITLE
Generated vs mocked

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
     "root": true,
-    "ignorePatterns": ["lib/*", "node_modules/**"],
+    "ignorePatterns": ["lib/*", "node_modules/**", "test/data/contracts/*.ts"],
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/eslint-recommended",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/contract",
     "description": "ContractKit for Wharf",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "homepage": "https://github.com/wharfkit/contract",
     "license": "BSD-3-Clause",
     "main": "lib/contract.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "wharf-generate": "./scripts/codegen-cli.js"
     },
     "dependencies": {
-        "@wharfkit/abicache": "^1.0.1-beta2",
+        "@wharfkit/abicache": "^1.1.0",
         "@wharfkit/antelope": "^0.7.3",
         "eosio-signing-request": "^3.0.0-beta1",
         "tslib": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/contract",
     "description": "ContractKit for Wharf",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "homepage": "https://github.com/wharfkit/contract",
     "license": "BSD-3-Clause",
     "main": "lib/contract.js",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@types/node": "^18.7.18",
         "@typescript-eslint/eslint-plugin": "^5.20.0",
         "@typescript-eslint/parser": "^5.20.0",
-        "@wharfkit/mock-data": "^1.0.0-beta13",
+        "@wharfkit/mock-data": "^1.0.0",
         "@wharfkit/session": "^1.0.0-beta9",
         "assert": "^2.0.0",
         "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
         "wharf-generate": "./scripts/codegen-cli.js"
     },
     "dependencies": {
-        "@wharfkit/abicache": "^1.1.0",
+        "@wharfkit/abicache": "^1.1.1",
         "@wharfkit/antelope": "^0.7.3",
-        "eosio-signing-request": "^3.0.0-beta1",
+        "@wharfkit/signing-request": "^3.0.0",
         "tslib": "^2.1.0"
     },
     "resolutions": {
@@ -43,7 +43,7 @@
         "@typescript-eslint/eslint-plugin": "^5.20.0",
         "@typescript-eslint/parser": "^5.20.0",
         "@wharfkit/mock-data": "^1.0.0-beta13",
-        "@wharfkit/session": "^1.0.0-beta6",
+        "@wharfkit/session": "^1.0.0-beta9",
         "assert": "^2.0.0",
         "chai": "^4.3.4",
         "eslint": "^8.13.0",
@@ -62,6 +62,7 @@
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.1.1",
         "typedoc": "^0.24.6",
-        "typescript": "^4.9.5"
+        "typescript": "^4.9.5",
+        "yarn-deduplicate": "^6.0.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/contract",
     "description": "ContractKit for Wharf",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "homepage": "https://github.com/wharfkit/contract",
     "license": "BSD-3-Clause",
     "main": "lib/contract.js",

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -30,7 +30,7 @@ export async function codegen(contractName, abi) {
         '@wharfkit/session'
     )
     const importContractStatement = generateImportStatement(
-        ['Contract as BaseContract', 'ContractArgs', 'blobStringToAbi'],
+        ['Contract as BaseContract', 'ContractArgs', 'PartialBy', 'blobStringToAbi'],
         '@wharfkit/contract'
     )
 

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -46,7 +46,7 @@ export async function codegen(contractName, abi) {
         const structMembers: ts.ClassElement[] = []
 
         for (const field of struct.fields) {
-            structMembers.push(generateField(field, true, `${namespaceName}.types`, abi))
+            structMembers.push(generateField(field, true, `${namespaceName}.Types`, abi))
         }
 
         structDeclarations.push(generateStruct(struct.structName, true, structMembers))
@@ -106,7 +106,7 @@ export async function codegen(contractName, abi) {
         abiBlobField,
         abiField,
         classDeclaration,
-        generateNamespace('types', structDeclarations),
+        generateNamespace('Types', structDeclarations),
     ])
 
     const sourceFile = ts.factory.createSourceFile(

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -34,7 +34,7 @@ export async function codegen(contractName, abi) {
         '@wharfkit/contract'
     )
 
-    const {classDeclaration} = await generateContractClass(namespaceName, contractName, abi)
+    const {classDeclaration} = await generateContractClass(namespaceName, contractName)
 
     // Extract fields from the ABI
     const structs = getFieldTypesFromAbi(abi)

--- a/src/codegen/contract.ts
+++ b/src/codegen/contract.ts
@@ -5,25 +5,8 @@ import {generateClassDeclaration} from './helpers'
 import {abiToBlob} from '../utils'
 
 export async function generateContractClass(namespaceName: string, contractName: string, abi: ABI) {
-    // Encode the ABI as a binary hex string
-    const abiBlob = abiToBlob(abi)
-
     // Prepare the member fields of the class
     const classMembers: ts.ClassElement[] = []
-
-    // Generate the private static `abiBlob` member
-    const abiField = ts.factory.createPropertyDeclaration(
-        undefined,
-        [
-            ts.factory.createModifier(ts.SyntaxKind.PrivateKeyword),
-            ts.factory.createModifier(ts.SyntaxKind.StaticKeyword),
-        ],
-        'abiBlob',
-        undefined,
-        undefined,
-        ts.factory.createStringLiteral(String(abiBlob))
-    )
-    classMembers.push(abiField)
 
     // Generate the `constructor` member
     const constructorParams: ts.ParameterDeclaration[] = [
@@ -62,16 +45,7 @@ export async function generateContractClass(namespaceName: string, contractName:
                             ),
                             ts.factory.createPropertyAssignment(
                                 'abi',
-                                ts.factory.createCallExpression(
-                                    ts.factory.createIdentifier('blobStringToAbi'),
-                                    undefined,
-                                    [
-                                        ts.factory.createPropertyAccessExpression(
-                                            ts.factory.createIdentifier(namespaceName),
-                                            'abiBlob'
-                                        ),
-                                    ]
-                                )
+                                ts.factory.createIdentifier('abi')
                             ),
                             ts.factory.createPropertyAssignment(
                                 'account',
@@ -103,8 +77,8 @@ export async function generateContractClass(namespaceName: string, contractName:
     classMembers.push(constructorMember)
 
     // Construct class declaration
-    const classDeclaration = generateClassDeclaration(namespaceName, classMembers, {
-        parent: 'Contract',
+    const classDeclaration = generateClassDeclaration('Contract', classMembers, {
+        parent: 'BaseContract',
         export: true,
     })
 

--- a/src/codegen/contract.ts
+++ b/src/codegen/contract.ts
@@ -1,10 +1,8 @@
 import * as ts from 'typescript'
-import {ABI} from '@wharfkit/session'
 
 import {generateClassDeclaration} from './helpers'
-import {abiToBlob} from '../utils'
 
-export async function generateContractClass(namespaceName: string, contractName: string, abi: ABI) {
+export async function generateContractClass(namespaceName: string, contractName: string) {
     // Prepare the member fields of the class
     const classMembers: ts.ClassElement[] = []
 

--- a/src/codegen/contract.ts
+++ b/src/codegen/contract.ts
@@ -14,7 +14,7 @@ export async function generateContractClass(namespaceName: string, contractName:
             undefined,
             'args',
             undefined,
-            ts.factory.createTypeReferenceNode(ts.factory.createIdentifier('Omit'), [
+            ts.factory.createTypeReferenceNode(ts.factory.createIdentifier('PartialBy'), [
                 ts.factory.createTypeReferenceNode(
                     ts.factory.createIdentifier('ContractArgs'),
                     undefined

--- a/src/codegen/helpers.ts
+++ b/src/codegen/helpers.ts
@@ -19,6 +19,7 @@ export const EOSIO_CORE_CLASSES = [
 
 export const EOSIO_CORE_TYPES = [
     'AssetType',
+    'Blob',
     'Checksum256Type',
     'Float64Type',
     'NameType',

--- a/src/codegen/namespace.ts
+++ b/src/codegen/namespace.ts
@@ -4,10 +4,10 @@ import {capitalize} from '../utils'
 
 // Generates a namespace name for a contract (eg. _EosioToken for eosio.token)
 export function generateNamespaceName(contractName: string) {
-    return `_${contractName
+    return contractName
         .split('.')
         .map((namePart) => capitalize(namePart))
-        .join('')}`
+        .join('')
 }
 
 export function generateNamespace(

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -10,7 +10,7 @@ import {
     PermissionLevel,
     PermissionLevelType,
 } from '@wharfkit/antelope'
-import {PlaceholderAuth} from 'eosio-signing-request'
+import {PlaceholderAuth} from '@wharfkit/signing-request'
 
 import {Table} from './contract/table'
 

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -49,8 +49,17 @@ export class Contract {
      * @param {ContractOptions} options - The options for the contract.
      */
     constructor(args: ContractArgs) {
+        if (!args.abi) {
+            throw new Error('Contract requires an ABI')
+        }
         this.abi = ABI.from(args.abi)
+        if (!args.account) {
+            throw new Error('Contract requires an account name')
+        }
         this.account = Name.from(args.account)
+        if (!args.client) {
+            throw new Error('Contract requires an APIClient')
+        }
         this.client = args.client
     }
 

--- a/src/index-module.ts
+++ b/src/index-module.ts
@@ -1,6 +1,5 @@
 export * from './contract'
 export * from './contract/table'
 export * from './contract/table-cursor'
-export * from './codegen'
 export * from './kit'
 export * from './utils'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,8 @@ import {
     UInt64,
 } from '@wharfkit/antelope'
 
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+
 export function pascalCase(value: string): string {
     return value
         .split(/_| /)

--- a/test/data/contracts/mock-rewards.ts
+++ b/test/data/contracts/mock-rewards.ts
@@ -1,0 +1,125 @@
+import {Contract as BaseContract, blobStringToAbi, ContractArgs} from '@wharfkit/contract'
+import {
+    ABI,
+    APIClient,
+    Asset,
+    AssetType,
+    Blob,
+    Checksum256,
+    Checksum256Type,
+    Float64,
+    Float64Type,
+    Name,
+    NameType,
+    Session,
+    Struct,
+    TimePoint,
+    TimePointSec,
+    TimePointType,
+    TransactResult,
+    UInt128,
+    UInt128Type,
+    UInt16,
+    UInt16Type,
+    UInt32,
+    UInt32Type,
+    UInt64,
+    UInt64Type,
+    UInt8,
+    UInt8Type,
+} from '@wharfkit/session'
+export namespace RewardsGm {
+    export const abiBlob = Blob.from(
+        'DmVvc2lvOjphYmkvMS4yAAoHYWRkdXNlcgACB2FjY291bnQEbmFtZQZ3ZWlnaHQGdWludDE2BWNsYWltAAIHYWNjb3VudARuYW1lBmFtb3VudAZhc3NldD8GY29uZmlnAAMMdG9rZW5fc3ltYm9sBnN5bWJvbA5vcmFjbGVfYWNjb3VudARuYW1lDG9yYWNsZV9wYWlycw1vcmFjbGVfcGFpcltdCWNvbmZpZ3VyZQADDHRva2VuX3N5bWJvbAZzeW1ib2wOb3JhY2xlX2FjY291bnQEbmFtZQxvcmFjbGVfcGFpcnMNb3JhY2xlX3BhaXJbXQdkZWx1c2VyAAEHYWNjb3VudARuYW1lC29yYWNsZV9wYWlyAAIEbmFtZQRuYW1lCXByZWNpc2lvbgZ1aW50MTYKcHJpY2VfaW5mbwADBHBhaXIGc3RyaW5nBXByaWNlB2Zsb2F0NjQJdGltZXN0YW1wCnRpbWVfcG9pbnQHcmVjZWlwdAADB2FjY291bnQEbmFtZQZhbW91bnQFYXNzZXQGdGlja2VyDHByaWNlX2luZm9bXQp1cGRhdGV1c2VyAAIHYWNjb3VudARuYW1lBndlaWdodAZ1aW50MTYIdXNlcl9yb3cAAwdhY2NvdW50BG5hbWUGd2VpZ2h0BnVpbnQxNgdiYWxhbmNlBWFzc2V0BgAAAOAqrFMyB2FkZHVzZXKVAi0tLQpzcGVjX3ZlcnNpb246ICIwLjIuMCIKdGl0bGU6IEFkZCB1c2VyCnN1bW1hcnk6ICdBZGQgbmV3IHVzZXIge3tub3dyYXAgYWNjb3VudH19JwppY29uOiBodHRwczovL2FsbW9zdC5kaWdpdGFsL2ltYWdlcy9taXNjX2ljb24ucG5nIzZmNWVhOTc4YjA0ZDAzZTAxOGIzNzlhMmJhYzRjMTBiNWE4ZmUwY2Q1ZTZlMTVjODg4MjhkYzk4NmJlOTZjZmYKLS0tCgp7e2FjY291bnR9fSBpcyBhZGRlZCB0byB0aGUgcmV3YXJkcyBzaGFyaW5nIGxpc3Qgd2l0aCB3ZWlnaHQge3t3ZWlnaHR9fS4AAAAAAOlMRAVjbGFpbfYCLS0tCnNwZWNfdmVyc2lvbjogIjAuMi4wIgp0aXRsZTogQ2xhaW0Kc3VtbWFyeTogJ0NsYWltIHJld2FyZHMgZm9yIHt7bm93cmFwIGFjY291bnR9fScKaWNvbjogaHR0cHM6Ly9hbG1vc3QuZGlnaXRhbC9pbWFnZXMvY2xhaW1faWNvbi5wbmcjYmI1OTdmNGFjYzEzMDU5MjU5MTJlMThlN2I0Y2Y3MDhkMWZhZWMyYWE4OGI3YTUzZDg3OTY5ZTA0NTE2OGVjZgotLS0KCnt7I2lmX2hhc192YWx1ZSBhbW91bnR9fQogICAge3thY2NvdW50fX0gY2xhaW1zIHt7YW1vdW50fX0gZnJvbSB0aGVpciByZXdhcmRzIGJhbGFuY2UuCnt7ZWxzZX19CiAgICB7e2FjY291bnR9fSBjbGFpbXMgdGhlaXIgZW50aXJlIHJld2FyZHMgYmFsYW5jZS4Ke3svaWZfaGFzX3ZhbHVlfX0AAFBXM7cmRQljb25maWd1cmUAAAAA4Cqso0oHZGVsdXNlcsQCLS0tCnNwZWNfdmVyc2lvbjogIjAuMi4wIgp0aXRsZTogRGVsZXRlIHVzZXIKc3VtbWFyeTogJ0RlbGV0ZSB1c2VyIHt7bm93cmFwIGFjY291bnR9fScKaWNvbjogaHR0cHM6Ly9hbG1vc3QuZGlnaXRhbC9pbWFnZXMvbWlzY19pY29uLnBuZyM2ZjVlYTk3OGIwNGQwM2UwMThiMzc5YTJiYWM0YzEwYjVhOGZlMGNkNWU2ZTE1Yzg4ODI4ZGM5ODZiZTk2Y2ZmCi0tLQoKe3thY2NvdW50fX0gaXMgaXMgcmVtb3ZlZCBmcm9tIHRoZSByZXdhcmRzIHNoYXJpbmcgbGlzdC4KClVzZXJzIGNhbiBvbmx5IGJlIHJlbW92ZWQgaWYgdGhlaXIgcmV3YXJkcyBiYWxhbmNlIGlzIHplcm8uAAAAIFenkLoHcmVjZWlwdAAAwFVYq2xS1Qp1cGRhdGV1c2VygAItLS0Kc3BlY192ZXJzaW9uOiAiMC4yLjAiCnRpdGxlOiBVcGRhdGUgdXNlcgpzdW1tYXJ5OiAnVXBkYXRlIHVzZXIge3tub3dyYXAgYWNjb3VudH19JwppY29uOiBodHRwczovL2FsbW9zdC5kaWdpdGFsL2ltYWdlcy9taXNjX2ljb24ucG5nIzZmNWVhOTc4YjA0ZDAzZTAxOGIzNzlhMmJhYzRjMTBiNWE4ZmUwY2Q1ZTZlMTVjODg4MjhkYzk4NmJlOTZjZmYKLS0tCgp7e2FjY291bnR9fSBpcyB1cGRhdGVkIHRvIGhhdmUgd2VpZ2h0IHt7d2VpZ2h0fX0uAgAAAAAwtyZFA2k2NAAABmNvbmZpZwAAAAAAfBXWA2k2NAAACHVzZXJfcm93AAAAAA=='
+    )
+    export const abi = ABI.from(abiBlob)
+    export class Contract extends BaseContract {
+        constructor(args: Omit<ContractArgs, 'abi' | 'account'>) {
+            super({
+                client: args.client,
+                abi: abi,
+                account: Name.from('rewards.gm'),
+            })
+        }
+    }
+    export namespace types {
+        @Struct.type('adduser')
+        export class Adduser extends Struct {
+            @Struct.field('name')
+            declare account: Name
+            @Struct.field('uint16')
+            declare weight: UInt16
+        }
+        @Struct.type('claim')
+        export class Claim extends Struct {
+            @Struct.field('name')
+            declare account: Name
+            @Struct.field('asset?')
+            declare amount: Asset
+        }
+        @Struct.type('config')
+        export class Config extends Struct {
+            @Struct.field('symbol')
+            declare token_symbol: symbol
+            @Struct.field('name')
+            declare oracle_account: Name
+            @Struct.field('oracle_pair[]')
+            declare oracle_pairs: RewardsGm.types.Oracle_pair
+        }
+        @Struct.type('configure')
+        export class Configure extends Struct {
+            @Struct.field('symbol')
+            declare token_symbol: symbol
+            @Struct.field('name')
+            declare oracle_account: Name
+            @Struct.field('oracle_pair[]')
+            declare oracle_pairs: RewardsGm.types.Oracle_pair
+        }
+        @Struct.type('deluser')
+        export class Deluser extends Struct {
+            @Struct.field('name')
+            declare account: Name
+        }
+        @Struct.type('oracle_pair')
+        export class Oracle_pair extends Struct {
+            @Struct.field('name')
+            declare name: Name
+            @Struct.field('uint16')
+            declare precision: UInt16
+        }
+        @Struct.type('price_info')
+        export class Price_info extends Struct {
+            @Struct.field('string')
+            declare pair: string
+            @Struct.field('float64')
+            declare price: Float64
+            @Struct.field('time_point')
+            declare timestamp: TimePoint
+        }
+        @Struct.type('receipt')
+        export class Receipt extends Struct {
+            @Struct.field('name')
+            declare account: Name
+            @Struct.field('asset')
+            declare amount: Asset
+            @Struct.field('price_info[]')
+            declare ticker: RewardsGm.types.Price_info
+        }
+        @Struct.type('updateuser')
+        export class Updateuser extends Struct {
+            @Struct.field('name')
+            declare account: Name
+            @Struct.field('uint16')
+            declare weight: UInt16
+        }
+        @Struct.type('user_row')
+        export class User_row extends Struct {
+            @Struct.field('name')
+            declare account: Name
+            @Struct.field('uint16')
+            declare weight: UInt16
+            @Struct.field('asset')
+            declare balance: Asset
+        }
+    }
+}

--- a/test/data/contracts/mock-rewards.ts
+++ b/test/data/contracts/mock-rewards.ts
@@ -1,31 +1,36 @@
-import {Contract as BaseContract, blobStringToAbi, ContractArgs} from '@wharfkit/contract'
+import {
+    Contract as BaseContract,
+    ContractArgs,
+    PartialBy,
+    blobStringToAbi,
+} from '@wharfkit/contract'
 import {
     ABI,
     APIClient,
-    Asset,
-    AssetType,
-    Blob,
-    Checksum256,
-    Checksum256Type,
-    Float64,
-    Float64Type,
-    Name,
-    NameType,
     Session,
     Struct,
+    TransactResult,
+    Asset,
+    Checksum256,
+    Float64,
+    Name,
     TimePoint,
     TimePointSec,
-    TimePointType,
-    TransactResult,
     UInt128,
-    UInt128Type,
     UInt16,
-    UInt16Type,
     UInt32,
-    UInt32Type,
     UInt64,
-    UInt64Type,
     UInt8,
+    AssetType,
+    Blob,
+    Checksum256Type,
+    Float64Type,
+    NameType,
+    TimePointType,
+    UInt128Type,
+    UInt16Type,
+    UInt32Type,
+    UInt64Type,
     UInt8Type,
 } from '@wharfkit/session'
 export namespace RewardsGm {
@@ -34,7 +39,7 @@ export namespace RewardsGm {
     )
     export const abi = ABI.from(abiBlob)
     export class Contract extends BaseContract {
-        constructor(args: Omit<ContractArgs, 'abi' | 'account'>) {
+        constructor(args: PartialBy<ContractArgs, 'abi' | 'account'>) {
             super({
                 client: args.client,
                 abi: abi,
@@ -60,7 +65,7 @@ export namespace RewardsGm {
         @Struct.type('config')
         export class Config extends Struct {
             @Struct.field('symbol')
-            declare token_symbol: symbol
+            declare token_symbol: Symbol
             @Struct.field('name')
             declare oracle_account: Name
             @Struct.field('oracle_pair[]')
@@ -69,7 +74,7 @@ export namespace RewardsGm {
         @Struct.type('configure')
         export class Configure extends Struct {
             @Struct.field('symbol')
-            declare token_symbol: symbol
+            declare token_symbol: Symbol
             @Struct.field('name')
             declare oracle_account: Name
             @Struct.field('oracle_pair[]')
@@ -90,7 +95,7 @@ export namespace RewardsGm {
         @Struct.type('price_info')
         export class Price_info extends Struct {
             @Struct.field('string')
-            declare pair: string
+            declare pair: String
             @Struct.field('float64')
             declare price: Float64
             @Struct.field('time_point')

--- a/test/data/contracts/mock-rewards.ts
+++ b/test/data/contracts/mock-rewards.ts
@@ -47,7 +47,7 @@ export namespace RewardsGm {
             })
         }
     }
-    export namespace types {
+    export namespace Types {
         @Struct.type('adduser')
         export class Adduser extends Struct {
             @Struct.field('name')
@@ -69,7 +69,7 @@ export namespace RewardsGm {
             @Struct.field('name')
             declare oracle_account: Name
             @Struct.field('oracle_pair[]')
-            declare oracle_pairs: RewardsGm.types.Oracle_pair
+            declare oracle_pairs: RewardsGm.Types.Oracle_pair
         }
         @Struct.type('configure')
         export class Configure extends Struct {
@@ -78,7 +78,7 @@ export namespace RewardsGm {
             @Struct.field('name')
             declare oracle_account: Name
             @Struct.field('oracle_pair[]')
-            declare oracle_pairs: RewardsGm.types.Oracle_pair
+            declare oracle_pairs: RewardsGm.Types.Oracle_pair
         }
         @Struct.type('deluser')
         export class Deluser extends Struct {
@@ -108,7 +108,7 @@ export namespace RewardsGm {
             @Struct.field('asset')
             declare amount: Asset
             @Struct.field('price_info[]')
-            declare ticker: RewardsGm.types.Price_info
+            declare ticker: RewardsGm.Types.Price_info
         }
         @Struct.type('updateuser')
         export class Updateuser extends Struct {

--- a/test/tests/codegen.ts
+++ b/test/tests/codegen.ts
@@ -1,9 +1,11 @@
 import {assert} from 'chai'
+import {ABI, APIClient, Name} from '@wharfkit/antelope'
 import {makeClient} from '@wharfkit/mock-data'
 
-import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codegen'
-import * as MockRewardsGm from '$test/data/contracts/mock-rewards'
 import {Contract} from 'src/contract'
+
+import * as MockRewardsGm from '$test/data/contracts/mock-rewards'
+import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codegen'
 ;(async function () {
     const GeneratedRewardsGm = await generateCodegenContract('rewards.gm')
     const contracts = {
@@ -15,22 +17,64 @@ import {Contract} from 'src/contract'
     suite('codegen', function () {
         test('Contracts are identical', function () {
             // TODO: We need a better way to compare the files too, like w/ imports etc
-            assert.equal(
-                JSON.stringify(contracts.MockRewardsGm),
-                JSON.stringify(contracts.GeneratedRewardsGm)
-            )
+            // assert.equal(
+            //     JSON.stringify(contracts.MockRewardsGm),
+            //     JSON.stringify(contracts.GeneratedRewardsGm)
+            // )
         })
         Object.keys(contracts).forEach((contractKey) => {
             suite(`Testing namespace ${contractKey}`, function () {
                 // The `RewardsGm` namespace
                 const testNamespace = contracts[contractKey].RewardsGm
+
                 // The `Contract` instance in the namespace
                 const testContract = testNamespace.Contract
 
+                function assertRewardsContract(contract) {
+                    assert.instanceOf(contract, Contract)
+                    assert.instanceOf(contract.abi, ABI)
+                    // assert.isTrue(contract.abi.equals(MockRewardsGm.abi))
+                    // assert.instanceOf(contract.account, Name)
+                    // assert.isTrue(contract.account.equals(testNamespace.account))
+                    assert.instanceOf(contract.client, APIClient)
+                }
+
                 suite('Contract', function () {
-                    test('valid instance', function () {
-                        const contract = new testContract({client})
-                        assert.instanceOf(contract, Contract)
+                    suite('constructor', function () {
+                        test('default', function () {
+                            const contract = new testContract({client})
+                            assertRewardsContract(contract)
+                        })
+                        test('accepted variants', function () {
+                            const c1 = new testContract({client})
+                            assertRewardsContract(c1)
+                            const c2 = new testContract({client, abi: testNamespace.abi})
+                            assertRewardsContract(c2)
+                            const c3 = new testContract({client, account: 'teamgreymass'})
+                            assertRewardsContract(c3)
+                            const c4 = new testContract({
+                                client,
+                                account: Name.from('teamgreymass'),
+                            })
+                            assertRewardsContract(c4)
+                            const c5 = new testContract({
+                                client,
+                                abi: testNamespace.abi,
+                                account: 'teamgreymass',
+                            })
+                            assertRewardsContract(c5)
+                        })
+                        test('invalid variants', function () {
+                            assert.throws(() => new testContract({abi: testNamespace.abi}))
+                            assert.throws(
+                                () =>
+                                    new testContract({
+                                        abi: testNamespace.abi,
+                                        account: 'teamgreymass',
+                                    })
+                            )
+                            assert.throws(() => new testContract({account: 'teamgreymass'}))
+                        })
                     })
                 })
             })

--- a/test/tests/codegen.ts
+++ b/test/tests/codegen.ts
@@ -2,38 +2,35 @@ import {assert} from 'chai'
 import {APIClient} from '@wharfkit/session'
 import {makeClient} from '@wharfkit/mock-data'
 
-import {Contract} from 'src/contract'
 import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codegen'
+import * as MockRewardsGm from '$test/data/contracts/mock-rewards'
+import {Contract} from 'src/contract'
+;(async function () {
+    const GeneratedRewardsGm = await generateCodegenContract('rewards.gm')
+    const contracts = {
+        MockRewardsGm,
+        GeneratedRewardsGm,
+    }
+    const client = makeClient('https://eos.greymass.com')
 
-let _RewardsGm
+    suite('codegen', function () {
+        Object.keys(contracts).forEach((contractKey) => {
+            suite(`Testing namespace ${contractKey}`, function () {
+                // The `RewardsGm` namespace
+                const testNamespace = contracts[contractKey].RewardsGm
+                // The `Contract` instance in the namespace
+                const testContract = testNamespace.Contract
 
-suite('codegen', function () {
-    setup(async () => {
-        const contractName = 'rewards.gm'
-
-        const contractPackage = await generateCodegenContract(contractName)
-
-        _RewardsGm = contractPackage._RewardsGm
-    })
-
-    teardown(() => {
-        removeCodegenContracts()
-    })
-
-    suite('_RewardsGm', function () {
-        let client: APIClient
-
-        // Setup before each test
-        setup(function () {
-            client = makeClient('https://eos.greymass.com')
-        })
-
-        suite('constructor', function () {
-            test('constructs the Contract instance', async function () {
-                const rewardsContract = new _RewardsGm({client})
-
-                assert.instanceOf(rewardsContract, Contract)
+                suite('Contract', function () {
+                    test('valid instance', function () {
+                        const contract = new testContract({client})
+                        assert.instanceOf(contract, Contract)
+                    })
+                })
             })
         })
+        teardown(() => {
+            removeCodegenContracts()
+        })
     })
-})
+})()

--- a/test/tests/codegen.ts
+++ b/test/tests/codegen.ts
@@ -6,6 +6,7 @@ import {Contract} from 'src/contract'
 
 import * as MockRewardsGm from '$test/data/contracts/mock-rewards'
 import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codegen'
+import {runGenericContractTests} from './contract'
 ;(async function () {
     const GeneratedRewardsGm = await generateCodegenContract('rewards.gm')
     const contracts = {
@@ -29,6 +30,7 @@ import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codeg
 
                 // The `Contract` instance in the namespace
                 const testContract = testNamespace.Contract
+                const testContractInstance = new testContract({client})
 
                 function assertRewardsContract(contract) {
                     assert.instanceOf(contract, Contract)
@@ -75,6 +77,7 @@ import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codeg
                             assert.throws(() => new testContract({account: 'teamgreymass'}))
                         })
                     })
+                    runGenericContractTests(testContractInstance)
                 })
             })
         })

--- a/test/tests/codegen.ts
+++ b/test/tests/codegen.ts
@@ -15,6 +15,7 @@ import {Contract} from 'src/contract'
 
     suite('codegen', function () {
         test('Contracts are identical', function () {
+            // TODO: We need a better way to compare the files too, like w/ imports etc
             assert.equal(
                 JSON.stringify(contracts.MockRewardsGm),
                 JSON.stringify(contracts.GeneratedRewardsGm)

--- a/test/tests/codegen.ts
+++ b/test/tests/codegen.ts
@@ -14,6 +14,12 @@ import {Contract} from 'src/contract'
     const client = makeClient('https://eos.greymass.com')
 
     suite('codegen', function () {
+        test('Contracts are identical', function () {
+            assert.equal(
+                JSON.stringify(contracts.MockRewardsGm),
+                JSON.stringify(contracts.GeneratedRewardsGm)
+            )
+        })
         Object.keys(contracts).forEach((contractKey) => {
             suite(`Testing namespace ${contractKey}`, function () {
                 // The `RewardsGm` namespace

--- a/test/tests/codegen.ts
+++ b/test/tests/codegen.ts
@@ -1,5 +1,4 @@
 import {assert} from 'chai'
-import {APIClient} from '@wharfkit/session'
 import {makeClient} from '@wharfkit/mock-data'
 
 import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codegen'

--- a/test/tests/codegen.ts
+++ b/test/tests/codegen.ts
@@ -17,10 +17,10 @@ import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codeg
     suite('codegen', function () {
         test('Contracts are identical', function () {
             // TODO: We need a better way to compare the files too, like w/ imports etc
-            // assert.equal(
-            //     JSON.stringify(contracts.MockRewardsGm),
-            //     JSON.stringify(contracts.GeneratedRewardsGm)
-            // )
+            assert.equal(
+                JSON.stringify(contracts.MockRewardsGm),
+                JSON.stringify(contracts.GeneratedRewardsGm)
+            )
         })
         Object.keys(contracts).forEach((contractKey) => {
             suite(`Testing namespace ${contractKey}`, function () {
@@ -33,9 +33,8 @@ import {generateCodegenContract, removeCodegenContracts} from '$test/utils/codeg
                 function assertRewardsContract(contract) {
                     assert.instanceOf(contract, Contract)
                     assert.instanceOf(contract.abi, ABI)
-                    // assert.isTrue(contract.abi.equals(MockRewardsGm.abi))
-                    // assert.instanceOf(contract.account, Name)
-                    // assert.isTrue(contract.account.equals(testNamespace.account))
+                    assert.isTrue(contract.abi.equals(testNamespace.abi))
+                    assert.instanceOf(contract.account, Name)
                     assert.instanceOf(contract.client, APIClient)
                 }
 

--- a/test/tests/contract.ts
+++ b/test/tests/contract.ts
@@ -60,13 +60,6 @@ const delegateBwData = {
     transfer: false,
 }
 
-// eosio.token::open
-const openData = {
-    owner: 'foo',
-    symbol: '4,EOS',
-    ram_payer: PlaceholderAuth.actor,
-}
-
 // eosio.token::transfer
 const transferData = {
     from: PlaceholderAuth.actor,

--- a/test/tests/contract.ts
+++ b/test/tests/contract.ts
@@ -75,275 +75,307 @@ const transferData = {
     memo: 'initial balance',
 }
 
-suite('Contract', () => {
-    let mockKit: ContractKit
-    let systemContract: Contract
-    let tokenContract: Contract
-
-    setup(async function () {
-        mockKit = new ContractKit({
-            client: mockClient,
-        })
-        systemContract = await mockKit.load('eosio')
-        tokenContract = await mockKit.load('eosio.token')
-    })
-
-    suite('construct', function () {
-        test('typed', function () {
-            const contract = new Contract({
-                ...systemContractArgs,
-                abi: ABI.from(systemContractArgs.abi),
-                account: Name.from(systemContractArgs.account),
-            })
-            assert.instanceOf(contract, Contract)
-        })
-        test('untyped', function () {
-            const contract = new Contract(systemContractArgs)
-            assert.instanceOf(contract, Contract)
-        })
-    })
-
+export function runGenericContractTests(contract: Contract) {
     suite('tableNames', function () {
-        test('list table names', function () {
-            assert.isArray(systemContract.tableNames)
-            assert.lengthOf(systemContract.tableNames, 26)
-            assert.isTrue(systemContract.tableNames.includes('voters'))
+        test('contains tables', function () {
+            assert.isArray(contract.tableNames)
+            assert.isTrue(contract.tableNames.length > 0)
         })
     })
-
     suite('table', function () {
         test('load table using Name', function () {
-            const table = systemContract.table('voters')
+            const tableName = Name.from(contract.tableNames[0])
+            const table = contract.table(tableName)
             assert.instanceOf(table, Table)
-            assert.isTrue(table.name.equals('voters'))
+            assert.isTrue(table.name.equals(tableName))
         })
         test('load table using string', function () {
-            const table = systemContract.table(Name.from('voters'))
+            const tableName = contract.tableNames[0]
+            const table = contract.table(tableName)
             assert.instanceOf(table, Table)
-            assert.isTrue(table.name.equals('voters'))
+            assert.isTrue(table.name.equals(tableName))
         })
         test('throws on invalid name', function () {
-            assert.throws(() => systemContract.table('foo'))
-        })
-        test('should pass rowType', async function () {
-            const table = systemContract.table<ProducerInfo>('producers', ProducerInfo)
-            assert.instanceOf(table, Table)
-            const producer = await table.get('lioninjungle')
-            assert.instanceOf(producer, ProducerInfo)
-            assert.instanceOf(producer.owner, Name)
-            assert.isTrue(producer.owner.equals('lioninjungle'))
+            assert.throws(() => contract.table('foo'))
         })
     })
-
-    suite('action', function () {
-        suite('load', function () {
-            test('using Name', function () {
-                const action = tokenContract.action(Name.from('transfer'), transferData)
-                assert.instanceOf(action, Action)
-                assert.isTrue(action.account.equals('eosio.token'))
-                assert.isTrue(action.name.equals('transfer'))
-                assert.isTrue(
-                    action.authorization[0].equals({
-                        actor: PlaceholderAuth.actor,
-                        permission: PlaceholderAuth.permission,
-                    })
-                )
-                const encoded = Serializer.encode({
-                    object: transferData,
-                    type: 'transfer',
-                    abi: tokenContract.abi,
-                })
-                assert.isTrue(action.data.equals(encoded))
-            })
-            test('using string', function () {
-                const action = tokenContract.action('transfer', transferData)
-                assert.instanceOf(action, Action)
-                assert.isTrue(action.account.equals('eosio.token'))
-                assert.isTrue(action.name.equals('transfer'))
-            })
-            test('defaults to placeholders', function () {
-                const action = tokenContract.action('transfer', transferData)
-                assert.isTrue(action.authorization[0].equals(PlaceholderAuth))
-            })
-        })
-        suite('throws', function () {
-            test('with incomplete action data', async function () {
-                assert.throws(() =>
-                    tokenContract.action('transfer', {
-                        from: 'foo',
-                        to: 'bar',
-                        quantity: '1.0000 EOS',
-                    })
-                )
-            })
-            test('with invalid action data', async function () {
-                assert.throws(() =>
-                    tokenContract.action('transfer', {
-                        ...transferData,
-                        to: Asset.from('1.0000 EOS'),
-                    })
-                )
-            })
-            test('with invalid name', async function () {
-                assert.throws(() => tokenContract.action('foo', transferData))
-            })
-        })
-        suite('overrides', function () {
-            test('authorization', async function () {
-                const action = tokenContract.action('transfer', transferData, {
-                    authorization: [
-                        {
-                            actor: 'foo',
-                            permission: 'bar',
-                        },
-                    ],
-                })
-                assert.isTrue(
-                    action.authorization[0].equals({
-                        actor: 'foo',
-                        permission: 'bar',
-                    })
-                )
-            })
-        })
-    })
-
-    suite('actions', function () {
-        test('create array of actions', async function () {
-            const actions: Action[] = [
-                ...systemContract.actions([
-                    {
-                        name: 'newaccount',
-                        data: newAccountData,
-                    },
-                    {
-                        name: 'buyrambytes',
-                        data: buyRamBytesData,
-                    },
-                    {
-                        name: 'delegatebw',
-                        data: delegateBwData,
-                    },
-                ]),
-                tokenContract.action('open', openData),
-            ]
-            assert.lengthOf(actions, 4)
-            assert.isTrue(actions[0].account.equals('eosio'))
-            assert.isTrue(actions[0].name.equals('newaccount'))
-            assert.lengthOf(actions[0].authorization, 1)
-            assert.isTrue(actions[0].authorization[0].equals(PlaceholderAuth))
-            assert.isTrue(actions[1].account.equals('eosio'))
-            assert.isTrue(actions[1].name.equals('buyrambytes'))
-            assert.lengthOf(actions[1].authorization, 1)
-            assert.isTrue(actions[1].authorization[0].equals(PlaceholderAuth))
-            assert.isTrue(actions[2].account.equals('eosio'))
-            assert.isTrue(actions[2].name.equals('delegatebw'))
-            assert.lengthOf(actions[2].authorization, 1)
-            assert.isTrue(actions[2].authorization[0].equals(PlaceholderAuth))
-            assert.isTrue(actions[3].account.equals('eosio.token'))
-            assert.isTrue(actions[3].name.equals('open'))
-            assert.lengthOf(actions[3].authorization, 1)
-            assert.isTrue(actions[3].authorization[0].equals(PlaceholderAuth))
-            const result = await mockSession.transact({actions})
-            if (!result.transaction) {
-                throw new Error('expected transaction')
-            }
-            assert.lengthOf(result.transaction.actions, 4)
-        })
-        suite('override', function () {
-            test('authorization (all)', function () {
-                const actions: Action[] = systemContract.actions(
-                    [
-                        {
-                            name: 'newaccount',
-                            data: newAccountData,
-                        },
-                        {
-                            name: 'buyrambytes',
-                            data: buyRamBytesData,
-                        },
-                        {
-                            name: 'delegatebw',
-                            data: delegateBwData,
-                        },
-                    ],
-                    {
-                        authorization: [{actor: 'foo', permission: 'bar'}],
-                    }
-                )
-                assert.lengthOf(actions, 3)
-                assert.isTrue(actions[0].authorization[0].actor.equals('foo'))
-                assert.isTrue(actions[0].authorization[0].permission.equals('bar'))
-                assert.lengthOf(actions[0].authorization, 1)
-                assert.isTrue(actions[1].authorization[0].actor.equals('foo'))
-                assert.isTrue(actions[1].authorization[0].permission.equals('bar'))
-                assert.lengthOf(actions[1].authorization, 1)
-                assert.isTrue(actions[2].authorization[0].actor.equals('foo'))
-                assert.isTrue(actions[2].authorization[0].permission.equals('bar'))
-                assert.lengthOf(actions[2].authorization, 1)
-            })
-            test('authorization (individual)', function () {
-                const actions: Action[] = systemContract.actions([
-                    {
-                        name: 'newaccount',
-                        data: newAccountData,
-                    },
-                    {
-                        name: 'buyrambytes',
-                        data: buyRamBytesData,
-                        authorization: [{actor: 'foo', permission: 'bar'}],
-                    },
-                    {
-                        name: 'delegatebw',
-                        data: delegateBwData,
-                    },
-                ])
-                assert.lengthOf(actions, 3)
-                assert.isTrue(actions[0].authorization[0].equals(PlaceholderAuth))
-                assert.lengthOf(actions[0].authorization, 1)
-                assert.isTrue(actions[1].authorization[0].actor.equals('foo'))
-                assert.isTrue(actions[1].authorization[0].permission.equals('bar'))
-                assert.lengthOf(actions[1].authorization, 1)
-                assert.isTrue(actions[2].authorization[0].equals(PlaceholderAuth))
-                assert.lengthOf(actions[2].authorization, 1)
-            })
-        })
-    })
-
     suite('actionNames', function () {
-        test('returns list', function () {
-            assert.isArray(systemContract.actionNames)
-            assert.lengthOf(systemContract.actionNames, 62)
-            assert.isTrue(systemContract.actionNames.includes('newaccount'))
+        test('contains actions', function () {
+            assert.isArray(contract.actionNames)
+            assert.isTrue(contract.actionNames.length > 0)
         })
     })
+    // TODO: Needs dynamic action data generation for tests to call `.action`
+    // suite('action', function () {
+    //     test('load action using Name', function () {
+    //         const tableName = Name.from(contract.actionNames[0])
+    //         const table = contract.action(tableName, {})
+    //         assert.instanceOf(table, Table)
+    //         assert.isTrue(table.name.equals(tableName))
+    //     })
+    //     test('load action using string', function () {
+    //         const tableName = contract.actionNames[0]
+    //         const table = contract.action(tableName, {})
+    //         assert.instanceOf(table, Table)
+    //         assert.isTrue(table.name.equals(tableName))
+    //     })
+    //     test('throws on invalid name', function () {
+    //         assert.throws(() => contract.action('foo', {}))
+    //     })
+    // })
+}
 
-    suite('ricardian', () => {
-        test('returns ricardian contract', async function () {
-            const kit = new ContractKit({
-                client: makeClient('https://eos.greymass.com'),
+;(async function () {
+    const mockKit = new ContractKit({
+        client: mockClient,
+    })
+    const systemContract = await mockKit.load('eosio')
+    const tokenContract = await mockKit.load('eosio.token')
+
+    suite('Contract', () => {
+        suite('construct', function () {
+            test('typed', function () {
+                const contract = new Contract({
+                    ...systemContractArgs,
+                    abi: ABI.from(systemContractArgs.abi),
+                    account: Name.from(systemContractArgs.account),
+                })
+                assert.instanceOf(contract, Contract)
             })
-            const contract = await kit.load('eosio.token')
-            const ricardian = await contract.ricardian('transfer')
-            assert.isString(ricardian)
+            test('untyped', function () {
+                const contract = new Contract(systemContractArgs)
+                assert.instanceOf(contract, Contract)
+            })
         })
-        test('throws for unknown action', async function () {
-            let error
-            try {
-                await tokenContract.ricardian('foo')
-            } catch (err) {
-                error = err
-            }
-            assert.instanceOf(error, Error)
+
+        suite('specific contract', function () {
+            suite('system contract', function () {
+                suite('generic tests', async () => {
+                    runGenericContractTests(systemContract)
+                })
+                suite('tableNames', function () {
+                    test('validate for contract', function () {
+                        assert.lengthOf(systemContract.tableNames, 26)
+                        assert.isTrue(systemContract.tableNames.includes('voters'))
+                    })
+                })
+                suite('table', function () {
+                    test('should accept rowType', async function () {
+                        const table = systemContract.table<ProducerInfo>('producers', ProducerInfo)
+                        assert.instanceOf(table, Table)
+                        const producer = await table.get('lioninjungle')
+                        assert.instanceOf(producer, ProducerInfo)
+                        assert.instanceOf(producer.owner, Name)
+                        assert.isTrue(producer.owner.equals('lioninjungle'))
+                    })
+                })
+                suite('actions', function () {
+                    test('create array of actions', async function () {
+                        const actions: Action[] = [
+                            ...systemContract.actions([
+                                {
+                                    name: 'newaccount',
+                                    data: newAccountData,
+                                },
+                                {
+                                    name: 'buyrambytes',
+                                    data: buyRamBytesData,
+                                },
+                                {
+                                    name: 'delegatebw',
+                                    data: delegateBwData,
+                                },
+                            ]),
+                        ]
+                        assert.lengthOf(actions, 3)
+                        assert.isTrue(actions[0].account.equals('eosio'))
+                        assert.isTrue(actions[0].name.equals('newaccount'))
+                        assert.lengthOf(actions[0].authorization, 1)
+                        assert.isTrue(actions[0].authorization[0].equals(PlaceholderAuth))
+                        assert.isTrue(actions[1].account.equals('eosio'))
+                        assert.isTrue(actions[1].name.equals('buyrambytes'))
+                        assert.lengthOf(actions[1].authorization, 1)
+                        assert.isTrue(actions[1].authorization[0].equals(PlaceholderAuth))
+                        assert.isTrue(actions[2].account.equals('eosio'))
+                        assert.isTrue(actions[2].name.equals('delegatebw'))
+                        assert.lengthOf(actions[2].authorization, 1)
+                        assert.isTrue(actions[2].authorization[0].equals(PlaceholderAuth))
+                        const result = await mockSession.transact({actions})
+                        if (!result.transaction) {
+                            throw new Error('expected transaction')
+                        }
+                        assert.lengthOf(result.transaction.actions, 3)
+                    })
+                    suite('override', function () {
+                        test('authorization (all)', function () {
+                            const actions: Action[] = systemContract.actions(
+                                [
+                                    {
+                                        name: 'newaccount',
+                                        data: newAccountData,
+                                    },
+                                    {
+                                        name: 'buyrambytes',
+                                        data: buyRamBytesData,
+                                    },
+                                    {
+                                        name: 'delegatebw',
+                                        data: delegateBwData,
+                                    },
+                                ],
+                                {
+                                    authorization: [{actor: 'foo', permission: 'bar'}],
+                                }
+                            )
+                            assert.lengthOf(actions, 3)
+                            assert.isTrue(actions[0].authorization[0].actor.equals('foo'))
+                            assert.isTrue(actions[0].authorization[0].permission.equals('bar'))
+                            assert.lengthOf(actions[0].authorization, 1)
+                            assert.isTrue(actions[1].authorization[0].actor.equals('foo'))
+                            assert.isTrue(actions[1].authorization[0].permission.equals('bar'))
+                            assert.lengthOf(actions[1].authorization, 1)
+                            assert.isTrue(actions[2].authorization[0].actor.equals('foo'))
+                            assert.isTrue(actions[2].authorization[0].permission.equals('bar'))
+                            assert.lengthOf(actions[2].authorization, 1)
+                        })
+                        test('authorization (individual)', function () {
+                            const actions: Action[] = systemContract.actions([
+                                {
+                                    name: 'newaccount',
+                                    data: newAccountData,
+                                },
+                                {
+                                    name: 'buyrambytes',
+                                    data: buyRamBytesData,
+                                    authorization: [{actor: 'foo', permission: 'bar'}],
+                                },
+                                {
+                                    name: 'delegatebw',
+                                    data: delegateBwData,
+                                },
+                            ])
+                            assert.lengthOf(actions, 3)
+                            assert.isTrue(actions[0].authorization[0].equals(PlaceholderAuth))
+                            assert.lengthOf(actions[0].authorization, 1)
+                            assert.isTrue(actions[1].authorization[0].actor.equals('foo'))
+                            assert.isTrue(actions[1].authorization[0].permission.equals('bar'))
+                            assert.lengthOf(actions[1].authorization, 1)
+                            assert.isTrue(actions[2].authorization[0].equals(PlaceholderAuth))
+                            assert.lengthOf(actions[2].authorization, 1)
+                        })
+                    })
+                })
+                suite('actionNames', function () {
+                    test('validate for contract', function () {
+                        assert.isArray(systemContract.actionNames)
+                        assert.lengthOf(systemContract.actionNames, 62)
+                        assert.isTrue(systemContract.actionNames.includes('newaccount'))
+                    })
+                })
+            })
+            suite('token contract', function () {
+                suite('action', function () {
+                    suite('load', function () {
+                        test('using Name', function () {
+                            const action = tokenContract.action(Name.from('transfer'), transferData)
+                            assert.instanceOf(action, Action)
+                            assert.isTrue(action.account.equals('eosio.token'))
+                            assert.isTrue(action.name.equals('transfer'))
+                            assert.isTrue(
+                                action.authorization[0].equals({
+                                    actor: PlaceholderAuth.actor,
+                                    permission: PlaceholderAuth.permission,
+                                })
+                            )
+                            const encoded = Serializer.encode({
+                                object: transferData,
+                                type: 'transfer',
+                                abi: tokenContract.abi,
+                            })
+                            assert.isTrue(action.data.equals(encoded))
+                        })
+                        test('using string', function () {
+                            const action = tokenContract.action('transfer', transferData)
+                            assert.instanceOf(action, Action)
+                            assert.isTrue(action.account.equals('eosio.token'))
+                            assert.isTrue(action.name.equals('transfer'))
+                        })
+                        test('defaults to placeholders', function () {
+                            const action = tokenContract.action('transfer', transferData)
+                            assert.isTrue(action.authorization[0].equals(PlaceholderAuth))
+                        })
+                    })
+                    suite('throws', function () {
+                        test('with incomplete action data', async function () {
+                            assert.throws(() =>
+                                tokenContract.action('transfer', {
+                                    from: 'foo',
+                                    to: 'bar',
+                                    quantity: '1.0000 EOS',
+                                })
+                            )
+                        })
+                        test('with invalid action data', async function () {
+                            assert.throws(() =>
+                                tokenContract.action('transfer', {
+                                    ...transferData,
+                                    to: Asset.from('1.0000 EOS'),
+                                })
+                            )
+                        })
+                        test('with invalid name', async function () {
+                            assert.throws(() => tokenContract.action('foo', transferData))
+                        })
+                    })
+                    suite('overrides', function () {
+                        test('authorization', async function () {
+                            const action = tokenContract.action('transfer', transferData, {
+                                authorization: [
+                                    {
+                                        actor: 'foo',
+                                        permission: 'bar',
+                                    },
+                                ],
+                            })
+                            assert.isTrue(
+                                action.authorization[0].equals({
+                                    actor: 'foo',
+                                    permission: 'bar',
+                                })
+                            )
+                        })
+                    })
+                })
+            })
         })
-        test('throws for an undefined ricardian', async function () {
-            let error
-            try {
-                await tokenContract.ricardian('transfer')
-            } catch (err) {
-                error = err
-            }
-            assert.instanceOf(error, Error)
+
+        suite('ricardian', () => {
+            test('returns ricardian contract', async function () {
+                const kit = new ContractKit({
+                    client: makeClient('https://eos.greymass.com'),
+                })
+                const contract = await kit.load('eosio.token')
+                const ricardian = await contract.ricardian('transfer')
+                assert.isString(ricardian)
+            })
+            test('throws for unknown action', async function () {
+                let error
+                try {
+                    await tokenContract.ricardian('foo')
+                } catch (err) {
+                    error = err
+                }
+                assert.instanceOf(error, Error)
+            })
+            test('throws for an undefined ricardian', async function () {
+                let error
+                try {
+                    await tokenContract.ricardian('transfer')
+                } catch (err) {
+                    error = err
+                }
+                assert.instanceOf(error, Error)
+            })
         })
     })
-})
+})()

--- a/test/tests/contract.ts
+++ b/test/tests/contract.ts
@@ -3,7 +3,7 @@ import {makeClient, mockPrivateKey, mockSession} from '@wharfkit/mock-data'
 
 import ContractKit, {Contract, ContractArgs, Table} from '$lib'
 import {ABI, Action, Asset, Name, PrivateKey, Serializer} from '@wharfkit/antelope'
-import {PlaceholderAuth} from 'eosio-signing-request'
+import {PlaceholderAuth} from '@wharfkit/signing-request'
 import {ProducerInfo} from '$test/data/structs/eosio'
 
 const mockClient = makeClient('https://jungle4.greymass.com')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,18 +1331,18 @@
   dependencies:
     tslib "^2.1.0"
 
-"@wharfkit/mock-data@^1.0.0-beta13":
-  version "1.0.0-beta13"
-  resolved "https://registry.yarnpkg.com/@wharfkit/mock-data/-/mock-data-1.0.0-beta13.tgz#ea603d54ad991aff770201a19f6904d5990061c6"
-  integrity sha512-pPUsQUEZCu6h54ez9XiSWm7KpdZFry31rdvZpLZiK0es++dOFEJOs7Y9IPpkcxhtCLQ6jGeDvLwExB4Pt2o9Lg==
+"@wharfkit/mock-data@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/mock-data/-/mock-data-1.0.0.tgz#f21f5f400021a4688985d779b902533aa9d75d70"
+  integrity sha512-OgzofVL8PQbr8Qh8ld1nKkkp4nJGW033Fdo7YF+2yPOxeieqUGClN+T6Ti4o6BXdY8hCQF4YRTzS8r5hON+UIg==
   dependencies:
     "@wharfkit/antelope" "^0.7.3"
-    "@wharfkit/session" "^1.0.0-beta6"
+    "@wharfkit/session" "^1.0.0-beta9"
     "@wharfkit/wallet-plugin-privatekey" "^0.5.0"
     node-fetch "^2.6.1"
     tslib "^2.1.0"
 
-"@wharfkit/session@^1.0.0-beta6", "@wharfkit/session@^1.0.0-beta9":
+"@wharfkit/session@^1.0.0-beta9":
   version "1.0.0-beta9"
   resolved "https://registry.yarnpkg.com/@wharfkit/session/-/session-1.0.0-beta9.tgz#854c7b019658328169e0893ab98b6b1efabe0edc"
   integrity sha512-ixPX0MrE/5vwxYym2j82lVVsEJSaCAHqgjd05AV/Iv+2o9QlTulN1LaAajCKJXzyT1bMwyI2dP+v7+dgKlVtRA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,7 +1016,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@3.1.0", "@jridgewell/resolve-uri@^3.0.3":
+"@jridgewell/resolve-uri@^3.0.3":
   version "3.1.0"
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
@@ -1034,26 +1034,18 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
   version "1.4.14"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/trace-mapping@0.3.9":
+"@jridgewell/trace-mapping@0.3.9", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
-
-"@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.17"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz"
-  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
-  dependencies:
-    "@jridgewell/resolve-uri" "3.1.0"
-    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@nicolo-ribaudo/semver-v6@^6.3.3":
   version "6.3.3"
@@ -1311,13 +1303,13 @@
     "@typescript-eslint/types" "5.41.0"
     eslint-visitor-keys "^3.3.0"
 
-"@wharfkit/abicache@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@wharfkit/abicache/-/abicache-1.1.0.tgz#71f4c784da3d8fc2f301904fd133b32bf0db83ca"
-  integrity sha512-MlY4oXVfCNi3GZmxDSMMf4Une69u+pGZD9T1LNY1uA5WCyxkSdGMt7Br8uXWWqPVABzCRnFjO6TGDo9iZJaD7g==
+"@wharfkit/abicache@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wharfkit/abicache/-/abicache-1.1.1.tgz#03624d03d9466e7def278786aaf074d274fc5650"
+  integrity sha512-CfpHzCLxFATcfReqdJDUxEDSHIeBF3jFx0cP8RcTDyhC2jX4cd+Q/wqjw/kCni3xrBM7cIGUp9c9NZdvdTK9Cg==
   dependencies:
     "@wharfkit/antelope" "^0.7.3"
-    eosio-signing-request "^3.0.0-beta1"
+    "@wharfkit/signing-request" "^3.0.0"
     pako "^2.0.4"
     tslib "^2.1.0"
 
@@ -1332,6 +1324,13 @@
     hash.js "^1.0.0"
     tslib "^2.0.3"
 
+"@wharfkit/common@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/common/-/common-1.1.0.tgz#1ee9dd1ba9e202002fadd20593f5f42a3e67c827"
+  integrity sha512-A1Ta8zrEXkuEQcEiEexG0BVrYOxqm75qbLYU9tGNhyw4z/vQiF6rzmCOqhmWGg6nE2J2GYPvrPZPZzDmRGtG+w==
+  dependencies:
+    tslib "^2.1.0"
+
 "@wharfkit/mock-data@^1.0.0-beta13":
   version "1.0.0-beta13"
   resolved "https://registry.yarnpkg.com/@wharfkit/mock-data/-/mock-data-1.0.0-beta13.tgz#ea603d54ad991aff770201a19f6904d5990061c6"
@@ -1343,15 +1342,25 @@
     node-fetch "^2.6.1"
     tslib "^2.1.0"
 
-"@wharfkit/session@^1.0.0-beta6":
-  version "1.0.0-beta6"
-  resolved "https://registry.yarnpkg.com/@wharfkit/session/-/session-1.0.0-beta6.tgz#802f7d275ff877b87666a42e544cdfbdcc961971"
-  integrity sha512-XeLN9kwBwNY8IrqWKx1losUjN3x34ICzcK4bIbjEiSR0mvLXj05WFRjMMYQrip1S9UYwmFAVRJUvFS1KQedwgA==
+"@wharfkit/session@^1.0.0-beta6", "@wharfkit/session@^1.0.0-beta9":
+  version "1.0.0-beta9"
+  resolved "https://registry.yarnpkg.com/@wharfkit/session/-/session-1.0.0-beta9.tgz#854c7b019658328169e0893ab98b6b1efabe0edc"
+  integrity sha512-ixPX0MrE/5vwxYym2j82lVVsEJSaCAHqgjd05AV/Iv+2o9QlTulN1LaAajCKJXzyT1bMwyI2dP+v7+dgKlVtRA==
   dependencies:
+    "@wharfkit/abicache" "^1.1.1"
     "@wharfkit/antelope" "^0.7.3"
-    eosio-signing-request "^3.0.0-beta1"
+    "@wharfkit/common" "^1.1.0"
+    "@wharfkit/signing-request" "^3.0.0"
     pako "^2.0.4"
     tslib "^2.1.0"
+
+"@wharfkit/signing-request@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/signing-request/-/signing-request-3.0.0.tgz#3464cdc76c0690ab241d805116101e3ed63ba846"
+  integrity sha512-+9UaznhYlZSgdZGG/LF5GkH7P9dCVh+b32cR1PYHKG6KuOsPlLqfv1DuWkqsxQyi3kGT1fXG1i8sl39ItgwLzg==
+  dependencies:
+    "@wharfkit/antelope" "^0.7.3"
+    tslib "^2.0.3"
 
 "@wharfkit/wallet-plugin-privatekey@^0.5.0":
   version "0.5.0"
@@ -1359,6 +1368,11 @@
   integrity sha512-dBpCLWnGfx2kUQUb3OKsKsTxbiFZvBkbh3v8LbnNHd4o/KyOCVbTwFQt6Jl+9QdlNzY2lESe+Ni/HDmfOHKVgg==
   dependencies:
     tslib "^2.1.0"
+
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -1729,6 +1743,11 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
 commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
@@ -1870,14 +1889,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-eosio-signing-request@^3.0.0-beta1:
-  version "3.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/eosio-signing-request/-/eosio-signing-request-3.0.0-beta1.tgz#96d29d11f802232a771a275cb255076b5117765c"
-  integrity sha512-fDtb1R9NHIUAkNEvny4x4L8oyfzsX13KKGb3/muk0PIvlGflFuIC+ATKl1e3x+b4dsYR4MFoylmMtJXdbb3Vsg==
-  dependencies:
-    "@wharfkit/antelope" "^0.7.3"
-    tslib "^2.0.3"
 
 es6-error@^4.0.1:
   version "4.1.1"
@@ -2266,7 +2277,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@7.2.0:
+glob@7.2.0, glob@^7.0.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.0"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -2275,18 +2286,6 @@ glob@7.2.0:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
-  version "7.2.3"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2867,7 +2866,7 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -3360,10 +3359,10 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.7:
-  version "7.3.8"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+semver@^7.3.7, semver@^7.5.0:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -3603,10 +3602,10 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.5.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
+  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -3833,7 +3832,7 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@20.2.4:
+yargs-parser@20.2.4, yargs-parser@^20.2.2:
   version "20.2.4"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
@@ -3845,11 +3844,6 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-unparser@2.0.0:
   version "2.0.0"
@@ -3890,6 +3884,16 @@ yargs@^15.0.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yarn-deduplicate@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-6.0.2.tgz#63498d2d4c3a8567e992a994ce0ab51aa5681f2e"
+  integrity sha512-Efx4XEj82BgbRJe5gvQbZmEO7pU5DgHgxohYZp98/+GwPqdU90RXtzvHirb7hGlde0sQqk5G3J3Woyjai8hVqA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    commander "^10.0.1"
+    semver "^7.5.0"
+    tslib "^2.5.0"
 
 yn@3.1.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,10 +1311,10 @@
     "@typescript-eslint/types" "5.41.0"
     eslint-visitor-keys "^3.3.0"
 
-"@wharfkit/abicache@^1.0.1-beta2":
-  version "1.0.1-beta2"
-  resolved "https://registry.yarnpkg.com/@wharfkit/abicache/-/abicache-1.0.1-beta2.tgz#e36d87484719a6afb34111de6a198ebaa79dfc99"
-  integrity sha512-vjcUUCQXfamGoUWHAfCvbEEBb5M80LuugxR6tYUk5nYJQ1L8oBZonSDl/q4iUEBD4CfMzUEU/vtVLQonfhEcDw==
+"@wharfkit/abicache@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wharfkit/abicache/-/abicache-1.1.0.tgz#71f4c784da3d8fc2f301904fd133b32bf0db83ca"
+  integrity sha512-MlY4oXVfCNi3GZmxDSMMf4Une69u+pGZD9T1LNY1uA5WCyxkSdGMt7Br8uXWWqPVABzCRnFjO6TGDo9iZJaD7g==
   dependencies:
     "@wharfkit/antelope" "^0.7.3"
     eosio-signing-request "^3.0.0-beta1"


### PR DESCRIPTION
Gotta say... this codegen stuff is pretty damn neat. 

So what this pull request does is a few things:

1. It pulls the `ABI` and `Blob` out of the `Contract` and places them in the root namespace and exposes them.
2. The `Contract` now uses the `abi` value from the root namespace during construction.
3. The `Contract` is moved into the namespace.
4. The `_` in front of the namespace is removed (we can discuss this, but I thought it wasn't needed?)
5. Creates a new "mock generated contract" (`test/data/contracts/mock-rewards.ts`) that we can manually craft to get the desired syntax we want.
6. Reworks the unit tests for code generation to ensure the generated and mock contracts are identical, as well as runs an entire suite against both of them to ensure they both function exactly the same.
7. Implemented `PartialBy` as described in https://github.com/wharfkit/contract/issues/44
8. Renamed `types` to `Types` in the namespace, since everything else is camel cased
9. Moved some `Contract` tests into a function called `runGenericContractTests` so we can run identical tests against static contracts, generated contracts, and mock contracts https://github.com/wharfkit/contract/pull/43/commits/66bf96042009d126cd8ba0462e19af32060c4621

Most of the changes I made were to make it so we could run tests against both a generated and mock contract at the same time. This was so we could work on adding/changing things in the mock contract, ensuring the tests pass, and then modify the code generator to output something that was identical to the mock contract.